### PR TITLE
make ExecResultMock implements sql.Result properly

### DIFF
--- a/pg/pgtest/pg.go
+++ b/pg/pgtest/pg.go
@@ -44,11 +44,11 @@ type ExecResultMock struct {
 	Err      error
 }
 
-func (m *ExecResultMock) LastInsertId() (int64, error) {
+func (m ExecResultMock) LastInsertId() (int64, error) {
 	return m.InsertID, m.Err
 }
 
-func (m *ExecResultMock) RowsAffected() (int64, error) {
+func (m ExecResultMock) RowsAffected() (int64, error) {
 	return m.Affected, m.Err
 }
 


### PR DESCRIPTION
ExecResultMock tried to implement sql.Result interface but did it wrong.  It caused a panic when Exec tried to cast this structure to interface.   